### PR TITLE
Rc 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # PromTracker changelog
 
+## 0.6.0
+
+* Add all new rts_ system values
+* Bump dependencies
+* Rename stablememory_size metric to rts_stable_memory_size 
+* Add ability to remove metrics by prefix/label
+* replace vector dependency by new-base
+
 ## 0.5.4
 
 * Bump dependencies

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ metrics.addSystemValues();
 
 ## Copyright
 
-MR Research AG, 2023-24
+MR Research AG, 2023-25
 
 ## Authors
 

--- a/mops.toml
+++ b/mops.toml
@@ -1,17 +1,20 @@
 [package]
 name = "promtracker"
-version = "0.5.4"
+version = "0.6.0"
 description = "Motoko value tracker for prometheus"
 repository = "https://github.com/research-ag/promtracker"
 keywords = [ "prometheus", "stats", "http", "metrics", "monitoring" ]
 license = "Apache-2.0"
 
 [dependencies]
-base = "0.14.9"
+base = "0.14.13"
 new-base = "0.4.0"
 
 [dev-dependencies]
 motoko-matchers = "https://github.com/kritzcreek/motoko-matchers#v1.3.0@3dac8a071b69e4e651b25a7d9683fe831eb7cffd"
 
-[toolchain]
+[requirements]
 moc = "0.14.9"
+
+[toolchain]
+moc = "0.14.13"


### PR DESCRIPTION
* Add all new rts_ system values
* Bump dependencies
* Rename stablememory_size metric to rts_stable_memory_size
* Add ability to remove metrics by prefix/label
* replace vector dependency by new-base